### PR TITLE
Fix auth token bearer

### DIFF
--- a/dfirtrack/settings.py
+++ b/dfirtrack/settings.py
@@ -154,7 +154,7 @@ REST_FRAMEWORK = {
 'DEFAULT_AUTHENTICATION_CLASSES' : [
    'rest_framework.authentication.BasicAuthentication',
    'rest_framework.authentication.SessionAuthentication',
-   'rest_framework.authentication.TokenAuthentication',
+    'dfirtrack_api.authentication.TokenAuthentication',
 ],
 'DEFAULT_PERMISSION_CLASSES': [
        'rest_framework.permissions.IsAuthenticated',

--- a/dfirtrack_api/authentication.py
+++ b/dfirtrack_api/authentication.py
@@ -1,0 +1,12 @@
+from rest_framework import authentication
+
+
+class TokenAuthentication(authentication.TokenAuthentication):
+    """
+    Simple token based authentication.
+    Clients should authenticate by passing the token key in the "Authorization"
+    HTTP header, prepended with the string "Token ".  For example:
+    Authorization: Token 401f7ac837da42b97f613d789819ff93537bee6a
+    """
+
+    keyword = 'Bearer'


### PR DESCRIPTION
Custom Authentication class in Django Rest Framework had to be implemented to overwrite the Bearer Token from "Token" to "Bearer" hence this is a de-facto standard and makes it easier to work with API Clients that have been generated using the OpenAPI Schema definition.

The API Clients in Python and Go use as Default the Token String "Bearer <TOKEN>" 